### PR TITLE
fix node import themes.py

### DIFF
--- a/pyironflow/themes.py
+++ b/pyironflow/themes.py
@@ -3,9 +3,7 @@ import typing
 from pyiron_workflow.nodes.function import Function
 from pyiron_workflow.nodes.macro import Macro
 from pyiron_workflow.nodes.transform import DataclassNode
-
-if typing.TYPE_CHECKING:
-    from pyiron_workflow.node import Node
+from pyiron_workflow.node import Node
 
 
 def get_color(node: Node, theme: typing.Literal['light']):


### PR DESCRIPTION
Current implementation throws NameError: name 'Node' is not defined Node class is imported only when the code is being type-checked, but not when it's being executed which causes the error.