### PR TITLE
Fix conda package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,3 @@
 include LICENSE
 include package.json
-include js/CustomNode.jsx
-include js/text-updater-node.css
-include js/widget.css
-include js/TextUpdaterNode.jsx
-include js/widget-drag-drop.jsx
-include js/widget.jsx
+include js/*


### PR DESCRIPTION
The `useElkLayout.jsx` file was not included in the `MANIFEST.in` resulting it not being uploaded to `pypi` which cases the conda package built to fail https://github.com/conda-forge/pyironflow-feedstock/pull/11