### PR TITLE
Add esbuild to deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
       shell: bash -l {0}
       run: |
         pip install versioneer[toml]==0.29
+        npx esbuild js/widget.jsx --minify --format=esm --bundle --outdir=pyironflow/static
         python setup.py sdist bdist_wheel
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The build error [here](https://github.com/pyiron/pyironFlow/actions/runs/13658075644/job/38182271955) indicates that when trying to import `__version__` from `pyironflow` there's an error because the js files are not in place yet.  @liamhuber writes [here](https://github.com/pyiron/pyironFlow/issues/44) that he worked around this by fiddling with the version sections of pyproject.toml.  I'm trying to be pragmatic here and just force building the js sources before we try to package.