### PR TITLE
Fix building with import

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,6 @@ jobs:
       shell: bash -l {0}
       run: |
         pip install versioneer[toml]==0.29
-        npx esbuild js/widget.jsx --minify --format=esm --bundle --outdir=pyironflow/static
         python setup.py sdist bdist_wheel
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyironflow/__init__.py
+++ b/pyironflow/__init__.py
@@ -4,4 +4,9 @@ from ._version import get_versions
 # Set version of pyiron_base
 __version__ = get_versions()["version"]
 
-from .pyironflow import PyironFlow
+try:
+    from .pyironflow import PyironFlow
+except FileNotFoundError:
+    print("WARNING: could not import PyironFlow, likely because js sources "
+          "are not build and we are in build env that just tries to get the "
+          "version number.")


### PR DESCRIPTION
See #66 which is reverted here.

Indeed downloading the package off PyPI confirms that we do not ship the build jsx files, but that these rather are only build on `pip install` on the local machine once the package has been downloaded.  The alternative solution would be to add `nodejs` to the build env in the workflow that build the package and manually build the js sources as in #66, but if this PR works, I'm gonna keep it for now.