### PR TITLE
Set version bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
     "anywidget", 
     "traitlets",
     "ipytree",
-    "ipython",
+    "ipython>=8.11,<9",
     "ipywidgets",
-    "pyiron_workflow",
+    "pyiron_workflow>=0.13.0,<1",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
IPython < 9 is required because ultratb.FormattedTB changes api in the color_scheme arg