### PR TITLE
Do not mangle just stick id into data dict

### DIFF
--- a/pyironflow/wf_extensions.py
+++ b/pyironflow/wf_extensions.py
@@ -23,7 +23,9 @@ def get_import_path(obj):
 
 def dict_to_node(dict_node):
     data = dict_node['data']
-    node = get_node_from_path(data['import_path'])(label=dict_node['id'])
+    label = dict_node['id']
+    node = get_node_from_path(data['import_path'])(label=label)
+
     if 'position' in dict_node:
         x, y = dict_node['position'].values()
         node.position = (x, y)
@@ -131,6 +133,7 @@ def get_node_dict(node, max_x, key=None):
             'failed': str(node.failed),
             'running': str(node.running),
             'ready': str(node.outputs.ready),
+            'python_object_id': id(node),
         },
         'position': get_node_position(node, max_x),
         'type': 'customNode',


### PR DESCRIPTION
Entirely surprisingly this makes things much simpler and fixes some edges cases I missed in #59 .

If I understand react correctly

https://github.com/pyiron/pyironFlow/blob/817e29cbd54cea50cc0b54d01b0e0935394dad3f/js/widget.jsx#L70
https://github.com/pyiron/pyironFlow/blob/817e29cbd54cea50cc0b54d01b0e0935394dad3f/js/widget.jsx#L73

means that we entirely control the contents of the nodes/edges jsons and the worries @Tara-Lakshmipathy and I had about react flow not keeping track of our ids were unfounded.  Anyway, I checked it in a notebook and I get back the ids I put in.