### PR TITLE
Try to style selected nodes

### DIFF
--- a/js/widget.css
+++ b/js/widget.css
@@ -8,10 +8,14 @@ html, body, #root {
 	font-family: sans-serif;
   }
 
-/* .react-flow__node:not(.selected) { */
-/*     border-color: black; */
-/* } */
+.react-flow__node:not(.selected) {
+    border: 4px solid rgba(0, 0, 0, .25);
+}
 
 .react-flow__node.selected {
-    border-color: red;
+    border: 4px solid rgba(0, 0, 0, .50);
+}
+
+.react-flow__edge-path {
+    stroke-width: 2px
 }

--- a/js/widget.css
+++ b/js/widget.css
@@ -7,3 +7,11 @@ html, body, #root {
 	box-sizing: border-box;
 	font-family: sans-serif;
   }
+
+/* .react-flow__node:not(.selected) { */
+/*     border-color: black; */
+/* } */
+
+.react-flow__node.selected {
+    border-color: red;
+}

--- a/js/widget.jsx
+++ b/js/widget.jsx
@@ -356,7 +356,7 @@ const render = createRender(() => {
       <UpdateDataContext.Provider value={updateData}> 
         <ReactFlow 
             nodes={nodes} 
-            edges={edges.map((edge) => ({ ...edge, style: { stroke: 'black', 'strokeWidth': 1 } }))}
+            edges={edges}
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}

--- a/js/widget.jsx
+++ b/js/widget.jsx
@@ -19,6 +19,7 @@ import CustomNode from './CustomNode.jsx';
 import {getLayoutedNodes2}  from './useElkLayout';
 
 import './text-updater-node.css';
+import './widget.css';
 
 /**
  * Author: Joerg Neugebauer

--- a/pyironflow/wf_extensions.py
+++ b/pyironflow/wf_extensions.py
@@ -151,8 +151,7 @@ def get_node_dict(node, max_x, key=None):
         },
         'position': get_node_position(node, max_x),
         'type': 'customNode',
-        'style': {'border': '1px black solid',
-                  'padding': 5,
+        'style': {'padding': 5,
                   'background': get_color(node=node, theme='light'),
                   'borderRadius': '10px',
                   'width': f'{node_width}px',
@@ -226,7 +225,6 @@ def get_edges(wf):
         edge_dict["target"] = inp_node
         edge_dict["targetHandle"] = inp_port
         edge_dict["id"] = ic
-        edge_dict["style"] = {'strokeWidth': 2, 'stroke': 'black',}
 
         edges.append(edge_dict)
     return edges


### PR DESCRIPTION
I'm trying to have selected nodes show up with a different border, but it's not quite working.  The css rule I use below is correct according to reactflow docs and the browser debugger confirms that a node I manually select matches it, but it is overriden by a more specific style on the element itself which forces the border to '1px solid black'.  This is strange because that's not the reactflow default and cannot find any code in this repo that applies such style to nodes.  Any ideas @Tara-Lakshmipathy 