### PR TITLE
Visualize current output

### DIFF
--- a/js/ContextMenu.css
+++ b/js/ContextMenu.css
@@ -1,0 +1,33 @@
+@import url('./widget.css');
+ 
+html,
+body {
+  margin: 0;
+  font-family: sans-serif;
+  box-sizing: border-box;
+}
+ 
+#app {
+  width: 100vw;
+  height: 100vh;
+}
+ 
+.context-menu {
+  background: white;
+  border-style: solid;
+  box-shadow: 10px 19px 20px rgba(0, 0, 0, 10%);
+  position: absolute;
+  z-index: 10;
+}
+ 
+.context-menu button {
+  border: none;
+  display: block;
+  padding: 0.5em;
+  text-align: left;
+  width: 100%;
+}
+ 
+.context-menu button:hover {
+  background: white;
+}

--- a/js/ContextMenu.jsx
+++ b/js/ContextMenu.jsx
@@ -1,0 +1,29 @@
+import React, { useCallback } from 'react';
+import { useReactFlow } from '@xyflow/react';
+ 
+export default function ContextMenu({
+  id,
+  data,
+  top,
+  left,
+  right,
+  bottom,
+  onOutput,
+  onSource,
+  ...props
+}) {
+
+  return (
+    <div
+      style={{ position: 'absolute', top: top, left: left, zIndex: 1000 }}
+      className="context-menu"
+      {...props}
+    >
+      <p style={{ margin: '0.5em' }}>
+        <b>node: {id}</b>
+      </p>
+      <button onClick={() => onOutput(data)} title="View the output(s) of this node without running it"> View Output</button>
+      <button onClick={() => onSource(data)} title="View the source code of this node">View Source</button>
+    </div>
+  );
+}

--- a/js/CustomNode.jsx
+++ b/js/CustomNode.jsx
@@ -272,8 +272,9 @@ export default memo(({ data, node_status }) => {
       >
           <button onClick={pullFunction} title="Run all connected upstream nodes and this node">Pull</button>
           <button onClick={pushFunction} title="Run this node and all connected downstream nodes">Push</button>
-          <button onClick={sourceFunction} title="Show the source code of this node">Source</button>
           <button onClick={resetFunction} title="Reset this node by clearing its cache">Reset</button>
+          <button onClick={outputFunction} title="View the current output(s) of this node">Output</button>
+          <button onClick={sourceFunction} title="Show the source code of this node">Source</button>
       </NodeToolbar>        
     </div>
   );

--- a/js/CustomNode.jsx
+++ b/js/CustomNode.jsx
@@ -46,19 +46,7 @@ export default memo(({ data, node_status }) => {
         model.save_changes();
     }
 
-    const outputFunction = () => {
-        // direct output of node to output widget
-        console.log('output: ', data.label)
-        model.set("commands", `output: ${data.label}`);
-        model.save_changes();
-    }
-
-    const sourceFunction = () => {
-        // show source code of node
-        console.log('source: ', data.label) 
-        model.set("commands", `source: ${data.label}`);
-        model.save_changes();        
-    }
+    // outputFunction and sourceFunction lifted to widget.jsx to be used by ContextMenu.jsx
 
     const resetFunction = () => {
         // reset state and cache of node
@@ -273,8 +261,6 @@ export default memo(({ data, node_status }) => {
           <button onClick={pullFunction} title="Run all connected upstream nodes and this node">Pull</button>
           <button onClick={pushFunction} title="Run this node and all connected downstream nodes">Push</button>
           <button onClick={resetFunction} title="Reset this node by clearing its cache">Reset</button>
-          <button onClick={outputFunction} title="View the current output(s) of this node">Output</button>
-          <button onClick={sourceFunction} title="Show the source code of this node">Source</button>
       </NodeToolbar>        
     </div>
   );

--- a/pyironflow/reactflow.py
+++ b/pyironflow/reactflow.py
@@ -298,7 +298,9 @@ class PyironFlowWidget:
                                 print(f"Could fetch outputs from node {node_name}!")
                             else:
                                 for out in node.outputs:
+                                    print(out.label + ":")
                                     display(out.value)
+                                    print("")
                             self.update_status()
                         case "delete_node":
                             self.wf.remove_child(node_name)

--- a/pyironflow/reactflow.py
+++ b/pyironflow/reactflow.py
@@ -293,6 +293,13 @@ class PyironFlowWidget:
                             else:
                                 self.display_return_value(node.push)
                             self.update_status()
+                        case "output":
+                            if error_message:
+                                print(f"Could fetch outputs from node {node_name}!")
+                            else:
+                                for out in node.outputs:
+                                    display(out.value)
+                            self.update_status()
                         case "delete_node":
                             self.wf.remove_child(node_name)
                         case command:


### PR DESCRIPTION
Visualize outputs of nodes without running them. Since, the node toolbar was getting crowded, shifted the buttons for viewing outputs and the source code to the node context menu.