### PR TITLE
Input type hints 1

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -99,22 +99,37 @@ pf = PyironFlow([wf], reload_node_library=True)
 - Currently, the kernel has to be restarted to use the new nodes listed when the "refresh" button is pressed. This will be fixed in an update.
 
 ## Input type hints for node developers <a name="node_devel"></a>
-The following type hints defined in the node functions result in interactive fields for users to specify inputs in the input ports:
+The following type (**primitive**) hints defined in the node functions result in interactive fields for users to specify inputs in the input ports:
 - `str`: gives a text field
 - `int`: gives a text field
 - `float`: gives a text field
 - `bool`: gives a checkbox
 - `Literal`: gives a drop down menu
-Other types, called **non-primitive** (e.g., `list`, `numpy.array`, custom objects etc.), do not result in interactive fields. Only a dot appears which can be used to connect with upstream output ports.
+- Other types, called **non-primitive** (e.g., `list`, `numpy.array`, custom objects etc.), do not result in interactive fields. Only a dot appears which can be used to connect with upstream output ports.
 
 If `Union` of types are used (also "`|`"), then the following apply:
-- `Union` between non-primitive and any one of `str`, `int`, `float` result in a text field.
-- `Union` between non-primitive and `bool` results in a checkbox.
-- `Union` between any of `str`, `int` and `float` will currently be parsed preferentially according that order - this will be fixed to correspond to the actual input entered by the user.
-- `Union` between `Literal` and `str` or `int` or `float` currently results in the corresponding input field of the other input type. E.g., `Union[Literal[1,2,3], str]` will result in a text field parsed as a string. This will not be supported in the future.
-- `Union` between `Literal` and `bool` will crash the widget. The crashing will be fixed, but it is not planned to support this typing.
-- `Union` between `Literal` (e.g., `Union[Literal["a"], Literal["b"], Literal["c"]]`) is currently not supported and will crash the widget. This will be fixed and supported.
-- `Union` consisting of only non-primitive types results in a dot for the input port.
+- `Union` between non-primitive and any one of `str`, `int`, `float` result in a text field and is parsed according to the primitive if entered.
+- `Union` between `int` and `float` (and other non-primitives) will be parsed according to the following example:
+  - 123 will be parsed as an `int` 123
+  - 123.0 will be parsed as an `int` 123
+  - 123.8 will be parsed as a `float` 123.8
+- `Union` between `int` and `str` (and other non-primitives) will be parsed according to the following example:
+  - 123 will be parsed as an `int` 123
+  - 123.0 will be parsed as an `int` 123
+  - 123.8 will be parsed as an `int` 123
+  - "foo" will be parsed as an `str` "foo"
+- `Union` between `int` and `float` (and other non-primitives) will be parsed according to the following example:
+  - 123 will be parsed as a `float` 123.0
+  - 123.0 will be parsed as an `float` 123.0
+  - 123.8 will be parsed as an `float` 123.8
+  - "foo" will be parsed as an `str` "foo"
+- `Union` between `int`, `float` and `str` (and other non-primitives) will be parsed according to the following example:
+  - 123 will be parsed as a `int` 123
+  - 123.0 will be parsed as an `int` 123
+  - 123.8 will be parsed as an `float` 123.8
+  - "foo" will be parsed as an `str` "foo"
+- `Union` between `bool` and any other type will throw an error in the jupyter log
+- `Union` between `Literal` and any other type will throw an error in the jupyter log
 
 ## Installation for module developers <a name="dev_install"></a>
 - Clone the repository to your file system

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -130,6 +130,7 @@ If `Union` of types are used (also "`|`"), then the following apply:
   - "foo" will be parsed as an `str` "foo"
 - `Union` between `bool` and any other type will throw an error in the jupyter log
 - `Union` between `Literal` and any other type will throw an error in the jupyter log
+- `Union` consisting of only non-primitive types results in a dot for the input port.
 
 ## Installation for module developers <a name="dev_install"></a>
 - Clone the repository to your file system

--- a/js/CustomNode.jsx
+++ b/js/CustomNode.jsx
@@ -103,6 +103,7 @@ export default memo(({ data, node_status }) => {
             'str': 'text',
             'int': 'text',
             'float': 'text',
+            'int-float': 'text',
             'bool': 'checkbox',
             '_LiteralGenericAlias': 'dropdown'
         };
@@ -117,6 +118,20 @@ export default memo(({ data, node_status }) => {
                     // Check if value can be converted to a float
                     const floatValue = parseFloat(value);
                     return isNaN(floatValue) ? value : floatValue;
+                case 'int-float':
+                    if (typeof value === 'string') {
+                        if (value.includes('.')) {
+                            // Parse as float if the string contains a decimal point
+                            const asFloat = parseFloat(value);
+                            return isNaN(asFloat) ? value : asFloat;
+                        } else if (/^-?\d+$/.test(value)) {
+                            // Parse as int if the string matches an integer pattern
+                            const asInt = parseInt(value, 10);
+                            return isNaN(asInt) ? value : asInt;
+                        } else {
+                            return value;
+                        }
+                    }
                 case 'bool':
                     return value; 
                 default:

--- a/pyironflow/wf_extensions.py
+++ b/pyironflow/wf_extensions.py
@@ -5,6 +5,7 @@ from pyironflow.themes import get_color
 import importlib
 import typing
 import warnings
+from typing import Union
 import types
 import math
 
@@ -95,6 +96,8 @@ def get_node_values(channel_dict):
 def _get_generic_type(t):
     non_none_types = [arg for arg in t.__args__ if arg is not type(None)]
     hints = {float, int, str}.intersection(non_none_types)
+    if int in hints and float in hints:
+        return Union[int,float]
     if int in hints:
         return int
     if float in hints:
@@ -108,6 +111,8 @@ def _get_type_name(t):
     primitive_types = (bool, str, int, float, typing._LiteralGenericAlias, type(None))
     if t is None:
         return 'None'
+    elif isinstance(t, (types.UnionType, typing._UnionGenericAlias)):
+        return 'int-float'
     elif t in primitive_types:
         return t.__name__
     else:


### PR DESCRIPTION
**Updates to work according to the following:**

The following type (primitive) hints defined in the node functions result in interactive fields for users to specify inputs in the input ports:
- str: gives a text field
- int: gives a text field
- float: gives a text field
- bool: gives a checkbox
- Literal: gives a drop down menu
- Other types, called non-primitive (e.g., list, numpy.array, custom objects etc.), do not result in interactive fields. Only a dot appears which can be used to connect with upstream output ports.

If Union of types are used (also "|"), then the following apply:
- Union between non-primitive and any one of str, int, float result in a text field and is parsed according to the primitive if entered.
- Union between int and float (and other non-primitives) will be parsed according to the following example:
  - 123 will be parsed as an int 123
  - 123.0 will be parsed as an int 123
  - 123.8 will be parsed as a float 123.8
- Union between int and str (and other non-primitives) will be parsed according to the following example:
  - 123 will be parsed as an int 123
  - 123.0 will be parsed as an int 123
  - 123.8 will be parsed as an int 123
  - "foo" will be parsed as an str "foo"
- Union between int and float (and other non-primitives) will be parsed according to the following example:
  - 123 will be parsed as a float 123.0
  - 123.0 will be parsed as an float 123.0
  - 123.8 will be parsed as an float 123.8
  - "foo" will be parsed as an str "foo"
- Union between int, float and str (and other non-primitives) will be parsed according to the following example:
  - 123 will be parsed as a int 123
  - 123.0 will be parsed as an int 123
  - 123.8 will be parsed as an float 123.8
  - "foo" will be parsed as an str "foo"
- Union between bool and any other type will throw an error in the jupyter log
- Union between Literal and any other type will throw an error in the jupyter log
- Union consisting of only non-primitive types results in a dot for the input port.
